### PR TITLE
Fix default anycable-go host, add missing `--redis-url` section

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -5,7 +5,7 @@ AnyCable uses [`anyway_config`](https://github.com/palkan/anyway_config) gem for
 You can also pass configuration variables to CLI as options, e.g.:
 
 ```sh
-$ bundle exec anycable --rpc-host 0.0.0.0:50120 \ 
+$ bundle exec anycable --rpc-host 0.0.0.0:50120 \
                        --redis-channel my_redis_channel \
                        --log-level debug
 ```
@@ -22,7 +22,7 @@ Here is the list of the most commonly used configuration parameters and the way 
 
 **rpc_host** (`ANYCABLE_RPC_HOST`, `--rpc-host`)
 
-Local address to run gRPC server on (default: `"[::]:50051"`).
+Local address to run gRPC server on (default: `"[::]:50051"`, deprecated, will be changed to `"127.0.0.1:50051"` in future versions).
 
 **redis_url** (`REDIS_URL`, `ANYCABLE_REDIS_URL`, `--redis-url`)
 

--- a/docs/go_getting_started.md
+++ b/docs/go_getting_started.md
@@ -54,6 +54,8 @@ RPC service address (default: `"localhost:50051"`).
 
 Comma-separated list of headers to proxy to RPC (default: `"cookie"`).
 
+**--redis_url** (`ANYCABLE_REDIS_URL` or `REDIS_URL`)
+
 Redis URL for pub/sub (default: `"redis://localhost:6379/5"`).
 
 **--redis_channel** (`ANYCABLE_REDIS_CHANNEL`)

--- a/docs/go_getting_started.md
+++ b/docs/go_getting_started.md
@@ -44,7 +44,7 @@ Here is the list of the most commonly used configuration parameters and the way 
 
 **--host**, **--port** (`ANYCABLE_HOST`, `ANYCABLE_PORT` or `PORT`)
 
-Server host and port (default: `"localhost"` and `8080`).
+Server host and port (default: `"0.0.0.0"` (deprecated, will be changed to `"localhost"` in future versions) and `8080`).
 
 **--rpc_host** (`ANYCABLE_RPC_HOST`)
 


### PR DESCRIPTION
Ref https://github.com/anycable/anycable-go/pull/62