### PR TITLE
Restore lost sidebar link to Kubernetes deployment

### DIFF
--- a/docs/v1/_sidebar.md
+++ b/docs/v1/_sidebar.md
@@ -32,6 +32,7 @@
 * Deployment
   * [Heroku](/deployment/heroku.md)
   * [Docker](/deployment/docker.md)
+  * [Kubernetes](/deployment/kubernetes.md)
   * [Capistrano](/deployment/capistrano.md)
   * [Systemd](/deployment/systemd.md)
   * [Load Balancing](/deployment/load_balancing.md)


### PR DESCRIPTION
Probably it was lost during docs versioning.