### PR TITLE
Fix typo - Acton cable -> Action cable

### DIFF
--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -39,6 +39,6 @@ Below you can see the snapshot of CPU usage during the RTT benchmark.
   </div>
   <div class="captioned-figure">
     <img src="/assets/images/actioncable.gif" alt="Action Cable CPU">
-    <label>Acton Cable</label>
+    <label>Action Cable</label>
   </div>
 </div>


### PR DESCRIPTION
`Acton cable` -> `Action cable`