### PR TITLE
fix: laravel composer package name at laravel guide

### DIFF
--- a/docs/guides/laravel.md
+++ b/docs/guides/laravel.md
@@ -17,7 +17,7 @@ AnyCable is a battle-proofed real-time server that's been in production at scale
 First, install the [anycable-laravel][] library:
 
 ```sh
-composer require anycable-laravel
+composer require anycable/laravel-broadcaster
 ```
 
 Then, configure the application to use `anycable` broadcasting driver. For that, add the AnyCable service provider to the `bootstrap/providers.php` file:


### PR DESCRIPTION
Wrong package name at laravel guide
![image](https://github.com/user-attachments/assets/bd11c7e1-3e67-4eaf-a460-7f13c334b459)