### PR TITLE
Fix docs discoverability: 301 redirects + sitemap.xml

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -12,6 +12,8 @@ export default withMermaid(defineConfig({
 
   sitemap: {
     hostname: 'https://docs.anycable.io',
+    // Drop leftover docsify folder-index stubs (/deployment/Readme, etc.).
+    transformItems: (items) => items.filter((i) => !/\/Readme$/i.test(i.url)),
   },
 
   vite: {

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -10,6 +10,10 @@ export default withMermaid(defineConfig({
   cleanUrls: true,
   ignoreDeadLinks: true,
 
+  sitemap: {
+    hostname: 'https://docs.anycable.io',
+  },
+
   vite: {
     plugins: [
       llmstxt(),

--- a/docs/public/_redirects
+++ b/docs/public/_redirects
@@ -1,0 +1,29 @@
+# 301 redirects for the docs URL restructure.
+# Old flat slugs (indexed by Google/Common Crawl/LLMs) now live under /anycable-go/*.
+# Netlify reads this file from the published site root.
+
+/signed_streams        /anycable-go/signed_streams        301
+/reliable_streams      /anycable-go/reliable_streams      301
+/presence              /anycable-go/presence              301
+/broadcasting          /anycable-go/broadcasting          301
+/jwt_identification    /anycable-go/jwt_identification     301
+/rpc                   /anycable-go/rpc                    301
+/sse                   /anycable-go/sse                    301
+/apollo                /anycable-go/apollo                 301
+/binary_formats        /anycable-go/binary_formats         301
+/long_polling          /anycable-go/long_polling           301
+/ocpp                  /anycable-go/ocpp                    301
+/pusher                /anycable-go/pusher                  301
+/broker                /anycable-go/broker                  301
+/pubsub                /anycable-go/pubsub                  301
+/instrumentation       /anycable-go/instrumentation        301
+/tracing               /anycable-go/tracing                301
+/os_tuning             /anycable-go/os_tuning              301
+/embedded_nats         /anycable-go/embedded_nats          301
+/library               /anycable-go/library                301
+/telemetry             /anycable-go/telemetry              301
+/configuration         /anycable-go/configuration          301
+/health_checking       /anycable-go/health_checking        301
+
+# The standalone anycable-go landing page was merged into the top-level guide.
+/anycable-go/getting_started   /getting_started            301

--- a/docs/public/_redirects
+++ b/docs/public/_redirects
@@ -27,3 +27,10 @@
 
 # The standalone anycable-go landing page was merged into the top-level guide.
 /anycable-go/getting_started   /getting_started            301
+
+# Older path schemes still linked around the web.
+/guides/anycable-go/*  /anycable-go/:splat                 301
+/edge/*                /:splat                              301
+
+# Common misspelling of the OCPP page.
+/anycable-go/occp      /anycable-go/ocpp                    301

--- a/docs/public/_redirects
+++ b/docs/public/_redirects
@@ -34,3 +34,9 @@
 
 # Common misspelling of the OCPP page.
 /anycable-go/occp      /anycable-go/ocpp                    301
+
+# Reliable streams once lived under /guides; siblings stayed there, so list it explicitly.
+/guides/reliable_streams   /anycable-go/reliable_streams   301
+
+# Misspelling of broadcast_adapters.
+/ruby/broadast_adapters    /ruby/broadcast_adapters        301


### PR DESCRIPTION
## Why

A Common Crawl analysis of docs discoverability (for LLMs/search) found that of 89 live pages, only **37%** are present in Common Crawl. Root cause: the VitePress restructure moved pages into `/anycable-go/*` (and other reshuffles) **without redirects**. The old URLs that Google/Common Crawl/LLMs already know now return **404** (e.g. `/signed_streams`, `/rpc`, `/sse`, `/guides/anycable-go/*`, `/edge/*`), while the new URLs are live but undiscovered. There was also no `sitemap.xml`.

## What

- **`docs/public/_redirects`** — 301s from every confirmed-404 old path to its current home. Each source was checked against the live site (404) and each target confirmed (200). Covers:
  - flat slugs → `/anycable-go/*` (e.g. `/signed_streams`, `/rpc`, `/sse`, `/apollo`, `/broadcasting`, …)
  - `/guides/anycable-go/*` → `/anycable-go/*` (splat)
  - `/edge/*` → `/*` (old edge docs version, splat)
  - `/anycable-go/occp` → `/anycable-go/ocpp` (misspelling)
  - `/anycable-go/getting_started` → `/getting_started` (page removed in restructure)
- **`sitemap` config** in `config.mts` — VitePress now emits `sitemap.xml` (75 current pages) at build. Submit it to Google Search Console after deploy.
- **`llms-full.txt` / `llms.txt`** — no change needed; generated by `vitepress-plugin-llms` at build, so they already track the new structure.

## Notes for review

- **Deploy target:** the live site (`docs.anycable.io`) is served by **Netlify**, which reads `_redirects` from the publish root. There's now also a GitHub Pages deploy workflow; GitHub Pages does **not** honor `_redirects`, so if production moves there, redirects need a different mechanism (the sitemap works on both).
- **Ambiguous slugs:** `/configuration` and `/health_checking` exist under both `/anycable-go/*` and `/ruby/*`. Both flat slugs point at the `anycable-go` server pages (the more externally linked ones).

## Test

`npm run build` succeeds; `dist/` contains `sitemap.xml`, `_redirects` at root, and regenerated `llms-full.txt`.