### PR TITLE
docs: Build-by-use-case guides

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,8 +12,6 @@ lefthook-local.yml
 # Local Netlify folder
 .netlify
 
-# Internal docs-rework working files (not for publication)
-DOCS_IMPROVEMENTS_SPEC.md
-FACT_CHECK.md
-DOCS_NOTES.md
+# Internal LLM working files (specs, notes, drafts) - not for publication
+.llm-docs/
 .DS_Store

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -63,6 +63,16 @@ export default withMermaid(defineConfig({
         ]
       },
       {
+        text: 'Build by use case',
+        items: [
+          { text: 'Overview', link: '/use-cases/' },
+          { text: 'AI response streaming', link: '/use-cases/ai-streaming' },
+          { text: 'Live dashboards', link: '/use-cases/live-dashboards' },
+          { text: 'GPS tracking & dispatch', link: '/use-cases/gps-dispatch' },
+          { text: 'Telehealth & collaboration', link: '/use-cases/telehealth' },
+        ]
+      },
+      {
         text: 'By backend',
         items: [
           { text: 'Rails', link: '/rails/getting_started' },

--- a/docs/.vitepress/theme/layouts/LandingLayout.vue
+++ b/docs/.vitepress/theme/layouts/LandingLayout.vue
@@ -74,6 +74,10 @@
             <h3>Capabilities</h3>
             <p>Delivery guarantees, recovery, presence, and zero-downtime deploys</p>
           </a>
+          <a class="path-card" href="/use-cases/">
+            <h3>Build by use case</h3>
+            <p>AI streaming, live dashboards, GPS dispatch, telehealth</p>
+          </a>
           <a class="path-card" href="/editions">
             <h3>Editions</h3>
             <p>Open source, Pro, and managed AnyCable+</p>

--- a/docs/use-cases/ai-streaming.md
+++ b/docs/use-cases/ai-streaming.md
@@ -1,4 +1,4 @@
-# Streaming AI responses
+# AI response streaming
 
 Streaming tokens from an LLM to the browser as they are generated is the
 expected UX for AI products. It looks simple until you account for reality: a
@@ -37,17 +37,23 @@ anycable-go --presets=broker --broadcast_adapter=http --public
 # in production, drop --public and use signed streams + JWT
 ```
 
+> Testing locally? Start the client (step 3) before broadcasting: a fresh
+> subscriber only receives messages sent after it connects, and reconnection is
+> what triggers history catch-up.
+
 ## 2. Stream tokens from your backend
 
 Pick a stream name per conversation, for example `ai/conversation/<id>`. As the
 LLM yields tokens, broadcast each one (or small groups, to reduce HTTP overhead).
+The `llm`, `prompt`, and `conversation_id`/`conversationId` below are your
+application's own objects.
 
 ::: code-group
 
 ```python [Python]
 import os, json, httpx
 
-url = os.environ["ANYCABLE_BROADCAST_URL"]  # e.g. http://localhost:8090/_broadcast
+url = os.environ.get("ANYCABLE_BROADCAST_URL", "http://localhost:8090/_broadcast")
 stream = f"ai/conversation/{conversation_id}"
 
 for chunk in llm.stream(prompt):           # your LLM client's streaming API
@@ -56,7 +62,7 @@ httpx.post(url, json={"stream": stream, "data": json.dumps({"done": True})})
 ```
 
 ```js [Node.js]
-const url = process.env.ANYCABLE_BROADCAST_URL // http://localhost:8090/_broadcast
+const url = process.env.ANYCABLE_BROADCAST_URL ?? 'http://localhost:8090/_broadcast'
 
 async function publish(stream, payload) {
   await fetch(url, {
@@ -135,14 +141,15 @@ The same properties give you two more things for free:
 - **Chunking.** Broadcasting every single token is fine for moderate volumes;
   batch a few tokens per broadcast if you are generating very fast or serving
   many concurrent conversations.
-- **Multi-node.** For more than one AnyCable instance, use a distributed broker
-  (NATS, or Redis on [Pro](../pro.md)) so history is shared across nodes.
+- **Multi-node.** For more than one AnyCable instance, use a distributed broker so
+  history is shared across nodes: NATS (currently experimental, and requiring a 3+
+  node JetStream cluster) or Redis on [Pro](../pro.md).
 
 ## Example apps
 
-- [twilio-ai-js-demo](https://github.com/anycable/twilio-ai-js-demo) — Next.js app
+- [twilio-ai-js-demo](https://github.com/anycable/twilio-ai-js-demo): a Next.js app
   streaming an OpenAI Realtime voice agent over Twilio Media Streams and AnyCable.
-- [twilio-ai-demo](https://github.com/anycable/twilio-ai-demo) — the same idea with
+- [twilio-ai-demo](https://github.com/anycable/twilio-ai-demo): the same idea with
   a Ruby backend.
 
 ## Related

--- a/docs/use-cases/ai-streaming.md
+++ b/docs/use-cases/ai-streaming.md
@@ -1,0 +1,152 @@
+# Streaming AI responses
+
+Streaming tokens from an LLM to the browser as they are generated is the
+expected UX for AI products. It looks simple until you account for reality: a
+long response takes tens of seconds, during which the user's connection can
+blink, they can switch tabs, or they can reopen the conversation on another
+device. If your transport is at-most-once, any token sent during a disconnect is
+lost, and the user sees a response with a hole in it.
+
+AnyCable solves this with [reliable streams](../anycable-go/reliable_streams.md):
+tokens are ordered and replayable, so a client that drops mid-response catches up
+on exactly what it missed.
+
+## Architecture
+
+```
+  Browser  ◄── WebSocket (ordered tokens, auto catch-up) ──  AnyCable
+                                                                ▲
+                                                                │ POST /_broadcast
+                                                                │ (one chunk per token/group)
+  Your backend (Python / Node / any) ── calls LLM ─────────────┘
+     streams tokens as they arrive
+```
+
+Your backend stays the only place that talks to the LLM. AnyCable owns the
+connection to the browser. There is no persistent link between them: the backend
+just POSTs each chunk over HTTP as it streams.
+
+## 1. Run the server
+
+For reliable, replayable delivery you need the [broker](../anycable-go/broker.md)
+enabled. The `broker` preset does that:
+
+```sh
+anycable-go --presets=broker --broadcast_adapter=http --public
+# --public is for local dev only (step 3 subscribes to an unsigned stream);
+# in production, drop --public and use signed streams + JWT
+```
+
+## 2. Stream tokens from your backend
+
+Pick a stream name per conversation, for example `ai/conversation/<id>`. As the
+LLM yields tokens, broadcast each one (or small groups, to reduce HTTP overhead).
+
+::: code-group
+
+```python [Python]
+import os, json, httpx
+
+url = os.environ["ANYCABLE_BROADCAST_URL"]  # e.g. http://localhost:8090/_broadcast
+stream = f"ai/conversation/{conversation_id}"
+
+for chunk in llm.stream(prompt):           # your LLM client's streaming API
+    httpx.post(url, json={"stream": stream, "data": json.dumps({"token": chunk.text})})
+httpx.post(url, json={"stream": stream, "data": json.dumps({"done": True})})
+```
+
+```js [Node.js]
+const url = process.env.ANYCABLE_BROADCAST_URL // http://localhost:8090/_broadcast
+
+async function publish(stream, payload) {
+  await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ stream, data: JSON.stringify(payload) }),
+  })
+}
+
+const stream = `ai/conversation/${conversationId}`
+for await (const chunk of llm.stream(prompt)) {  // your LLM client's streaming API
+  await publish(stream, { token: chunk.text })
+}
+await publish(stream, { done: true })
+```
+
+:::
+
+## 3. Render tokens on the client
+
+Use the [AnyCable client SDK](https://github.com/anycable/anycable-client) with
+the extended protocol so reconnection and catch-up happen automatically:
+
+```js
+import { createCable } from '@anycable/web'
+
+const cable = createCable('ws://localhost:8080/cable', { protocol: 'actioncable-v1-ext-json' })
+const channel = cable.streamFrom(`ai/conversation/${conversationId}`)
+
+let answer = ''
+channel.on('message', (msg) => {
+  if (msg.done) return finalize(answer)
+  answer += msg.token          // append in arrival order
+  render(answer)
+})
+```
+
+That is the whole client. The SDK tracks the last offset it received; when the
+connection drops and recovers, it requests the missed tokens and the server
+replays them in order before resuming the live stream.
+
+## Why this holds up
+
+This scenario is verified against a running server. Streaming five tokens to a
+stream, a connected client receives them in order:
+
+```
+1:The  2:quick  3:brown  4:fox  5:jumps
+```
+
+When a client drops after token 3 and reconnects, it requests history from
+offset 3 and receives exactly the missed tokens, no gaps and no duplicates:
+
+```
+catch-up from offset 3 -> 4:fox  5:jumps  (+ confirm_history)
+```
+
+The same properties give you two more things for free:
+
+- **Multiple viewers / multiple devices.** Anyone subscribed to the conversation
+  stream sees the same tokens. Open the conversation on a second device and it
+  catches up to the current state.
+- **Survives your deploys.** Because AnyCable is a separate process, deploying
+  your app mid-generation does not drop the user's stream. See
+  [zero-downtime deploys](../capabilities.md#deploys).
+
+## Production notes
+
+- **Secure the streams.** Replace `--public` with [signed
+  streams](../anycable-go/signed_streams.md) so a user can only subscribe to
+  their own conversations, and authenticate connections with
+  [JWT](../anycable-go/jwt_identification.md).
+- **History window.** Tune `--history_limit` and `--history_ttl` to cover the
+  longest plausible disconnect during a response. Defaults are 100 messages /
+  300 seconds.
+- **Chunking.** Broadcasting every single token is fine for moderate volumes;
+  batch a few tokens per broadcast if you are generating very fast or serving
+  many concurrent conversations.
+- **Multi-node.** For more than one AnyCable instance, use a distributed broker
+  (NATS, or Redis on [Pro](../pro.md)) so history is shared across nodes.
+
+## Example apps
+
+- [twilio-ai-js-demo](https://github.com/anycable/twilio-ai-js-demo) — Next.js app
+  streaming an OpenAI Realtime voice agent over Twilio Media Streams and AnyCable.
+- [twilio-ai-demo](https://github.com/anycable/twilio-ai-demo) — the same idea with
+  a Ruby backend.
+
+## Related
+
+- [Reliable streams and resumable sessions](../anycable-go/reliable_streams.md)
+- [Capabilities: delivery guarantees](../capabilities.md#delivery-guarantees)
+- [Quick Start: any backend](../quickstart.md#any-backend)

--- a/docs/use-cases/gps-dispatch.md
+++ b/docs/use-cases/gps-dispatch.md
@@ -1,0 +1,114 @@
+# GPS tracking & dispatch
+
+Field services, delivery, ride-hailing, and logistics apps track moving assets in
+real time: drivers, vehicles, couriers. Two questions dominate the realtime
+layer. Where is each asset right now, and which assets are online and available
+to dispatch? The first is an ordered stream of location updates; the second is
+presence.
+
+AnyCable provides both, plus the resilience these apps need: devices on cellular
+networks disconnect constantly, and updates must not be lost or arrive out of
+order.
+
+## Architecture
+
+```
+  Devices (drivers)  ──► your backend ──► POST /_broadcast ──► AnyCable
+   location updates                                              │
+                                                                 ▼
+  Dispatchers / customers ◄────────── WebSocket ────────── location streams
+                                                          + presence (who's online)
+```
+
+- **Location stream per asset** (`driver/<id>/location`), so a customer watching
+  one delivery subscribes to just that asset.
+- **A dispatch-area presence set** so dispatchers see which drivers are online.
+
+## 1. Run the server
+
+```sh
+anycable-go --presets=broker --broadcast_adapter=http --public
+# --public is for local dev only (the client below subscribes to unsigned streams);
+# in production, drop --public and use signed streams + JWT
+```
+
+The `broker` preset enables both ordered, replayable location streams and
+[presence](../anycable-go/presence.md).
+
+## 2. Ingest and broadcast location updates
+
+Devices send updates to your backend (HTTP, MQTT, whatever you already use). Your
+backend broadcasts each one to the asset's stream:
+
+```python
+import os, json, httpx
+
+BROADCAST_URL = os.environ["ANYCABLE_BROADCAST_URL"]  # e.g. http://localhost:8090/_broadcast
+
+def publish(stream, payload):
+    httpx.post(BROADCAST_URL, json={"stream": stream, "data": json.dumps(payload)})
+
+def on_location(driver_id, lat, lng, ts):
+    publish(f"driver/{driver_id}/location", {"lat": lat, "lng": lng, "ts": ts})
+```
+
+Updates carry ordered offsets, so a watcher that reconnects after a tunnel or a
+dead zone catches up rather than jumping to a stale-then-current position.
+
+## 3. Watch a driver and track who is online
+
+```js
+import { createCable } from '@anycable/web'
+const cable = createCable('ws://localhost:8080/cable', { protocol: 'actioncable-v1-ext-json' })
+
+// Follow one driver's position
+const track = cable.streamFrom('driver/42/location')
+track.on('message', ({ lat, lng }) => moveMarker(lat, lng))
+
+// Dispatch board: who is online right now
+const board = cable.streamFrom('dispatch/online-drivers')
+board.on('presence', ({ type, id, info }) => {
+  if (type === 'join') addDriver(id, info)
+  if (type === 'leave') removeDriver(id)
+})
+const online = await board.presence.info()
+```
+
+A driver's app joins the presence set when it goes on shift:
+
+```js
+const board = cable.streamFrom('dispatch/online-drivers')
+await board.presence.join(driver.id, { name: driver.name, vehicle: driver.vehicle })
+```
+
+## Why this holds up
+
+- **Presence is built in and verified.** Two clients sharing a presence set see
+  each other's `join` and `leave` events, and `presence.info()` returns the full
+  set. A driver that disconnects lingers for a short, configurable window
+  (`--presence_ttl`, default 15s) so a brief signal drop does not flicker them
+  off the board.
+- **No lost or reordered positions.** Location updates are ordered and replayable
+  on reconnect. See [delivery guarantees](../capabilities.md#delivery-guarantees).
+- **Survives deploys.** Drivers and dispatchers stay connected through your
+  releases. See [zero-downtime deploys](../capabilities.md#deploys).
+
+## Production notes
+
+- **Presence TTL vs. flaky cellular.** Raise `--presence_ttl` if drivers
+  routinely lose signal for longer than 15 seconds, so they are not marked
+  offline prematurely.
+- **Update rate.** Throttle device updates (for example, one per 2-5 seconds, or
+  on meaningful movement) to control bandwidth and battery.
+- **Authorization.** Sign stream names with [signed
+  streams](../anycable-go/signed_streams.md) so a customer can only watch their
+  own delivery, and authenticate devices with
+  [JWT](../anycable-go/jwt_identification.md).
+- **IoT protocols.** For EV-charging stations, AnyCable Pro speaks the
+  [OCPP](../anycable-go/ocpp.md) WebSocket protocol (currently alpha).
+
+## Related
+
+- [Presence tracking](../anycable-go/presence.md)
+- [Reliable streams](../anycable-go/reliable_streams.md)
+- [REST API](../anycable-go/api.md) for reading presence sets server-side

--- a/docs/use-cases/gps-dispatch.md
+++ b/docs/use-cases/gps-dispatch.md
@@ -43,7 +43,7 @@ backend broadcasts each one to the asset's stream:
 ```python
 import os, json, httpx
 
-BROADCAST_URL = os.environ["ANYCABLE_BROADCAST_URL"]  # e.g. http://localhost:8090/_broadcast
+BROADCAST_URL = os.environ.get("ANYCABLE_BROADCAST_URL", "http://localhost:8090/_broadcast")
 
 def publish(stream, payload):
     httpx.post(BROADCAST_URL, json={"stream": stream, "data": json.dumps(payload)})
@@ -71,12 +71,16 @@ board.on('presence', ({ type, id, info }) => {
   if (type === 'join') addDriver(id, info)
   if (type === 'leave') removeDriver(id)
 })
-const online = await board.presence.info()
+renderRoster(await board.presence.info())   // seed the board with whoever is already online
 ```
 
-A driver's app joins the presence set when it goes on shift:
+A driver's app joins the presence set when it goes on shift (`driver` is the
+signed-in driver record from your app):
 
 ```js
+import { createCable } from '@anycable/web'
+
+const cable = createCable('ws://localhost:8080/cable', { protocol: 'actioncable-v1-ext-json' })
 const board = cable.streamFrom('dispatch/online-drivers')
 await board.presence.join(driver.id, { name: driver.name, vehicle: driver.vehicle })
 ```
@@ -105,7 +109,12 @@ await board.presence.join(driver.id, { name: driver.name, vehicle: driver.vehicl
   own delivery, and authenticate devices with
   [JWT](../anycable-go/jwt_identification.md).
 - **IoT protocols.** For EV-charging stations, AnyCable Pro speaks the
-  [OCPP](../anycable-go/ocpp.md) WebSocket protocol (currently alpha).
+  [OCPP](../anycable-go/ocpp.md) WebSocket protocol (alpha; integrates through
+  Action Cable on a Ruby/Rails backend).
+- **Multi-node presence.** The in-memory `broker` preset above is single-node. To
+  run more than one AnyCable instance, use the Redis broker on [Pro](../pro.md)
+  (Redis 7.4+ / Valkey 9.0+ required) so presence and history span nodes. See
+  [presence](../anycable-go/presence.md).
 
 ## Related
 

--- a/docs/use-cases/index.md
+++ b/docs/use-cases/index.md
@@ -1,0 +1,20 @@
+# Build by use case
+
+AnyCable powers realtime features across many domains. These guides start from
+what you are building, show the architecture, and link to the features involved.
+Every guide is verified against a running server.
+
+| Use case | What you get | Guide |
+|---|---|---|
+| **Streaming AI responses** | Ordered token streaming with mid-response catch-up | [AI response streaming](./ai-streaming.md) |
+| **Live dashboards** | High fan-out market data, metrics, and feeds | [Live dashboards](./live-dashboards.md) |
+| **Location tracking & dispatch** | Device location streams with online-driver presence | [GPS tracking & dispatch](./gps-dispatch.md) |
+| **Telehealth & collaboration** | Presence and reliable messaging for sessions | [Telehealth & collaboration](./telehealth.md) |
+
+All of these build on the same primitives:
+
+- [Delivery guarantees & recovery](../capabilities.md#delivery-guarantees) so messages survive connection blips
+- [Presence](../capabilities.md#presence) to track who is online
+- [Zero-downtime deploys](../capabilities.md#deploys) so realtime keeps working through releases
+
+New to AnyCable? Start with the [Quick Start](../quickstart.md).

--- a/docs/use-cases/index.md
+++ b/docs/use-cases/index.md
@@ -6,9 +6,9 @@ Every guide is verified against a running server.
 
 | Use case | What you get | Guide |
 |---|---|---|
-| **Streaming AI responses** | Ordered token streaming with mid-response catch-up | [AI response streaming](./ai-streaming.md) |
+| **AI response streaming** | Ordered token streaming with mid-response catch-up | [AI response streaming](./ai-streaming.md) |
 | **Live dashboards** | High fan-out market data, metrics, and feeds | [Live dashboards](./live-dashboards.md) |
-| **Location tracking & dispatch** | Device location streams with online-driver presence | [GPS tracking & dispatch](./gps-dispatch.md) |
+| **GPS tracking & dispatch** | Device location streams with online-driver presence | [GPS tracking & dispatch](./gps-dispatch.md) |
 | **Telehealth & collaboration** | Presence and reliable messaging for sessions | [Telehealth & collaboration](./telehealth.md) |
 
 All of these build on the same primitives:

--- a/docs/use-cases/live-dashboards.md
+++ b/docs/use-cases/live-dashboards.md
@@ -32,6 +32,10 @@ anycable-go --presets=broker --broadcast_adapter=http --public
 The `broker` preset gives subscribers catch-up on reconnect, which matters for
 dashboards where a missed update leaves stale numbers on screen.
 
+> Testing locally? Open the dashboard client (step 3) before publishing: a new
+> subscriber receives updates sent after it connects, and catch-up replays what it
+> missed on reconnect.
+
 ## 2. Publish updates
 
 Broadcast each update to the feed's stream. The producer can be a cron job, a
@@ -40,7 +44,7 @@ market-data consumer, or your application reacting to changes.
 ```python
 import os, json, httpx
 
-BROADCAST_URL = os.environ["ANYCABLE_BROADCAST_URL"]  # e.g. http://localhost:8090/_broadcast
+BROADCAST_URL = os.environ.get("ANYCABLE_BROADCAST_URL", "http://localhost:8090/_broadcast")
 
 def publish(stream, payload):
     httpx.post(BROADCAST_URL, json={"stream": stream, "data": json.dumps(payload)})
@@ -73,7 +77,7 @@ each widget calls `streamFrom` with its own feed name.
 - **Fan-out is one broadcast.** Verified with multiple subscribers on one
   stream: a single publish reaches all of them. In the
   [benchmark](https://anycable.io/compare/nodejs-websocket/)'s broadcast-throughput
-  test (10,000 subscribers, 1M messages from 40 parallel publishers), AnyCable
+  test (10,000 subscribers, 1M deliveries from 40 parallel publishers), AnyCable
   delivered at a **4 ms median** versus 155 ms for default Socket.IO. (This is the
   fan-out throughput test, distinct from the latency numbers on the
   [Capabilities](../capabilities.md#efficiency) page.)

--- a/docs/use-cases/live-dashboards.md
+++ b/docs/use-cases/live-dashboards.md
@@ -1,0 +1,105 @@
+# Live dashboards
+
+Market data tickers, analytics dashboards, live ops boards, and leaderboards all
+share one shape: one source of truth produces frequent updates, and many viewers
+need them at once with low latency. The hard parts are fan-out (one update,
+thousands of subscribers) and consistency (a viewer should not silently miss a
+price change during a network blip).
+
+AnyCable handles both: high fan-out from a single broadcast, and
+[reliable streams](../anycable-go/reliable_streams.md) so viewers catch up after
+a disconnect.
+
+## Architecture
+
+```
+  Many browsers ◄── WebSocket ──  AnyCable  ◄── POST /_broadcast ── Your producer
+   (dashboards)                  (fan-out)                          (price feed,
+                                                                     metrics job)
+```
+
+One stream per dashboard or per data feed. Your producer broadcasts each update
+once; AnyCable fans it out to every subscriber.
+
+## 1. Run the server
+
+```sh
+anycable-go --presets=broker --broadcast_adapter=http --public
+# --public is for local dev only (the client below subscribes to unsigned streams);
+# in production, drop --public and use signed streams + JWT
+```
+
+The `broker` preset gives subscribers catch-up on reconnect, which matters for
+dashboards where a missed update leaves stale numbers on screen.
+
+## 2. Publish updates
+
+Broadcast each update to the feed's stream. The producer can be a cron job, a
+market-data consumer, or your application reacting to changes.
+
+```python
+import os, json, httpx
+
+BROADCAST_URL = os.environ["ANYCABLE_BROADCAST_URL"]  # e.g. http://localhost:8090/_broadcast
+
+def publish(stream, payload):
+    httpx.post(BROADCAST_URL, json={"stream": stream, "data": json.dumps(payload)})
+
+# e.g. a price tick
+publish("market/AAPL", {"price": 196.42, "ts": 1718900000})
+```
+
+A single broadcast reaches every subscriber of that stream. There is no
+per-connection loop in your code.
+
+## 3. Subscribe from the dashboard
+
+```js
+import { createCable } from '@anycable/web'
+
+const cable = createCable('ws://localhost:8080/cable', { protocol: 'actioncable-v1-ext-json' })
+const ticker = cable.streamFrom('market/AAPL')
+
+ticker.on('message', (update) => {
+  applyToChart(update)   // arrives in order; catch-up is automatic on reconnect
+})
+```
+
+Subscribe to several streams from one connection for a multi-widget dashboard:
+each widget calls `streamFrom` with its own feed name.
+
+## Why this holds up
+
+- **Fan-out is one broadcast.** Verified with multiple subscribers on one
+  stream: a single publish reaches all of them. In the
+  [benchmark](https://anycable.io/compare/nodejs-websocket/)'s broadcast-throughput
+  test (10,000 subscribers, 1M messages from 40 parallel publishers), AnyCable
+  delivered at a **4 ms median** versus 155 ms for default Socket.IO. (This is the
+  fan-out throughput test, distinct from the latency numbers on the
+  [Capabilities](../capabilities.md#efficiency) page.)
+- **No stale screens after a blip.** Updates carry ordered offsets, so a viewer
+  that reconnects pulls the updates it missed rather than waiting for the next
+  tick. See [delivery guarantees](../capabilities.md#delivery-guarantees).
+- **Survives deploys.** A release of your app does not disconnect viewers. See
+  [zero-downtime deploys](../capabilities.md#deploys).
+
+## Production notes
+
+- **Snapshot + deltas.** For a dashboard that should show correct state
+  immediately on load, send a current snapshot from your HTTP API on page load,
+  then apply deltas from the stream. The stream's history covers gaps during the
+  session.
+- **Rate.** For very high-frequency feeds, coalesce updates server-side (for
+  example, one broadcast per 100 ms per symbol) rather than one per change.
+- **Authorization.** Use [signed streams](../anycable-go/signed_streams.md) so a
+  viewer only subscribes to feeds they are entitled to (per-tenant dashboards,
+  paid symbols).
+- **Public read-only feeds.** For genuinely public data, you can enable
+  [public streams](../anycable-go/signed_streams.md#public-unsigned-streams)
+  (`--public_streams` / `ANYCABLE_PUBLIC_STREAMS`) instead of signing each name.
+
+## Related
+
+- [Broadcasting](../anycable-go/broadcasting.md)
+- [Capabilities: efficiency at scale](../capabilities.md#efficiency)
+- [Signed streams](../anycable-go/signed_streams.md)

--- a/docs/use-cases/telehealth.md
+++ b/docs/use-cases/telehealth.md
@@ -22,8 +22,8 @@ recoverable messaging, and self-hosted or on-premise deployment for compliance.
 ```
 
 One stream per session (`consultation/<id>`) carries presence and messages.
-WebRTC media flows peer-to-peer; AnyCable carries the signaling and session
-state, not the video itself.
+WebRTC media flows peer-to-peer; AnyCable carries only the signaling and session
+state.
 
 ## 1. Run the server
 
@@ -71,7 +71,7 @@ your backend:
 ```python
 import os, json, httpx
 
-BROADCAST_URL = os.environ["ANYCABLE_BROADCAST_URL"]  # e.g. http://localhost:8090/_broadcast
+BROADCAST_URL = os.environ.get("ANYCABLE_BROADCAST_URL", "http://localhost:8090/_broadcast")
 
 def publish(stream, payload):
     httpx.post(BROADCAST_URL, json={"stream": stream, "data": json.dumps(payload)})
@@ -108,6 +108,9 @@ them. See [delivery guarantees](../capabilities.md#delivery-guarantees).
 - **Audit and data residency.** Running the server yourself keeps session
   metadata within your boundary. Pair with your existing logging and audit
   pipeline.
+- **Multi-node presence.** The in-memory `broker` preset is single-node. To scale
+  beyond one AnyCable instance, use the Redis broker on [Pro](../pro.md) (Redis
+  7.4+ / Valkey 9.0+ required) so presence and history are shared across nodes.
 
 ## Related
 

--- a/docs/use-cases/telehealth.md
+++ b/docs/use-cases/telehealth.md
@@ -1,0 +1,116 @@
+# Telehealth & collaboration
+
+A telehealth consultation, a shared document, or a support session has the same
+realtime needs: each participant must know who else is present, messages and
+signaling must arrive reliably and in order, and the session must not drop when
+you deploy. For healthcare specifically, where the data is sensitive, you also
+need control over where the realtime server runs.
+
+AnyCable covers all of this: [presence](../anycable-go/presence.md) for who is in
+the room, [reliable streams](../anycable-go/reliable_streams.md) for ordered,
+recoverable messaging, and self-hosted or on-premise deployment for compliance.
+
+## Architecture
+
+```
+  Patient  ◄── WebSocket ──┐
+                           ├── AnyCable ── presence (who's in the room)
+  Clinician ◄── WebSocket ─┘   (self-hosted)  reliable session stream
+                                 ▲
+                                 │ POST /_broadcast (chat, status, signaling)
+                            Your backend
+```
+
+One stream per session (`consultation/<id>`) carries presence and messages.
+WebRTC media flows peer-to-peer; AnyCable carries the signaling and session
+state, not the video itself.
+
+## 1. Run the server
+
+```sh
+anycable-go --presets=broker --broadcast_adapter=http --public
+# --public is for local dev only (the client below subscribes to unsigned streams);
+# in production, drop --public and require JWT + signed streams (see Production notes)
+```
+
+For sensitive data, run AnyCable inside your own infrastructure. It is a single
+self-hosted Go binary with no external dependencies in the standalone setup, so
+it fits on-premise and isolated environments. See [Docker](../deployment/docker.md) or [Kubernetes](../deployment/kubernetes.md) deployment.
+
+## 2. Join the session and track presence
+
+```js
+import { createCable } from '@anycable/web'
+const cable = createCable('ws://localhost:8080/cable', { protocol: 'actioncable-v1-ext-json' })
+
+const session = cable.streamFrom('consultation/abc123')
+
+// Announce yourself to the room
+await session.presence.join(user.id, { name: user.name, role: user.role })
+
+// React to the other party joining or leaving
+session.on('presence', ({ type, id, info }) => {
+  if (type === 'join') showParticipant(info)
+  if (type === 'leave') showWaiting(info)
+})
+
+// Who is in the room right now
+const inRoom = await session.presence.info()
+```
+
+This is verified behavior: when one participant joins, the other receives a
+`join` event with their info; `presence.info()` returns the full set; leaving (or
+disconnecting) emits a `leave`. A short presence TTL keeps a brief network drop
+from ejecting someone mid-consultation.
+
+## 3. Exchange messages and signaling
+
+Broadcast chat, status changes, and WebRTC signaling to the session stream from
+your backend:
+
+```python
+import os, json, httpx
+
+BROADCAST_URL = os.environ["ANYCABLE_BROADCAST_URL"]  # e.g. http://localhost:8090/_broadcast
+
+def publish(stream, payload):
+    httpx.post(BROADCAST_URL, json={"stream": stream, "data": json.dumps(payload)})
+
+def send_to_session(session_id, event):
+    publish(f"consultation/{session_id}", event)
+
+send_to_session("abc123", {"type": "chat", "from": "clinician", "text": "Can you hear me?"})
+```
+
+Because the stream is ordered and replayable, a participant whose connection
+blinks rejoins and catches up on the messages they missed rather than losing
+them. See [delivery guarantees](../capabilities.md#delivery-guarantees).
+
+## Why this holds up
+
+- **Presence is built in and verified end-to-end** (join/leave/info across
+  clients), so "is my doctor here yet?" is answered without custom code.
+- **No dropped consultations on deploy.** AnyCable is a separate process, so
+  releasing your app does not disconnect an in-progress session. See
+  [zero-downtime deploys](../capabilities.md#deploys).
+- **You control the deployment.** Self-host or run on-premise for HIPAA and
+  similar requirements. [AnyCable+](https://plus.anycable.io) also offers managed
+  options when you do not need on-premise.
+
+## Production notes
+
+- **Authorization.** Authenticate every participant with
+  [JWT](../anycable-go/jwt_identification.md) and restrict each session stream
+  with [signed streams](../anycable-go/signed_streams.md), so only the patient
+  and clinician can join a given consultation.
+- **Presence TTL.** Tune `--presence_ttl` to your tolerance for brief
+  disconnects during a call.
+- **Audit and data residency.** Running the server yourself keeps session
+  metadata within your boundary. Pair with your existing logging and audit
+  pipeline.
+
+## Related
+
+- [Presence tracking](../anycable-go/presence.md)
+- [Reliable streams](../anycable-go/reliable_streams.md)
+- [JWT authentication](../anycable-go/jwt_identification.md)


### PR DESCRIPTION
## Summary

Adds the **Build by use case** guides, split out of the repositioning PR (#59, now merged) per Vladimir's review feedback. These pages start from what the reader is building, show the architecture, and link into the front-door and capability pages that landed in #59.

## Pages

- **AI response streaming** — ordered token streaming with mid-response catch-up
- **Live dashboards** — high fan-out market data / metrics feeds
- **GPS tracking & dispatch** — device location streams with online-driver presence
- **Telehealth & collaboration** — presence + reliable messaging for sessions
- **Index** ("Build by use case"), plus the sidebar group and the landing-page card

## Verification

Every scenario was exercised against a running `anycable-go`: ordered token streaming and history catch-up (AI), fan-out to multiple subscribers (dashboards), presence join/leave/info via the real `@anycable/core` SDK (GPS/telehealth). Each `--public` dev command, signed-streams/JWT production note, and `publish` example is self-contained and copy-paste runnable; the JS clients pass an explicit `ws://localhost:8080/cable` for the standalone Node/Python persona. forspell/markdownlint clean, build passes, and every internal link resolves against the merged tree.

## Notes
- Stacked on #59 (merged); base is current `master`.
- Incorporates all the use-case fixes from the #59 review passes (undefined `BROADCAST_URL`, the `--public` dev commands, scoped benchmark figure, OCPP-alpha wording, self-contained `publish` helpers).