### PR TITLE
docs(python): tighten the Python guide (house-style)

### DIFF
--- a/docs/guides/python.md
+++ b/docs/guides/python.md
@@ -10,15 +10,6 @@ This is the same [standalone pub/sub](../quickstart.md#any-backend) model used b
 any HTTP backend. The examples below are Python, but the three moving parts (a
 JWT, a signed stream name, an HTTP broadcast) are identical in every language.
 
-## Architecture
-
-```
-  Browser ◄── WebSocket ── AnyCable ◄── POST /_broadcast ── Your Python app
-                              ▲                              (Django / FastAPI /
-                              │ JWT (?jid=...) on connect     Flask / ...)
-                              │ signed stream names
-```
-
 ## 1. Run the server
 
 ```sh
@@ -101,6 +92,10 @@ broadcast("chat/1", {"text": "Hello from Python"})
 > port and require an auth key, see [securing the broadcast
 > endpoint](../anycable-go/broadcasting.md#securing-http-endpoint).
 
+That's it. Your Python backend now drives realtime through three HTTP-level
+pieces: a token, a signed stream name, and a POST. No SDK, no persistent
+connection to maintain.
+
 ## Framework notes
 
 The integration is the same regardless of framework, because it is just token
@@ -111,13 +106,6 @@ issuing, stream signing, and HTTP POSTs:
 - **FastAPI / Flask**: issue tokens in a route; broadcast from request handlers
   or background workers.
 - **Any other backend**: replicate the three snippets above in your language.
-
-## Verified behavior
-
-Every step here is exercised against a running server: a Python-generated JWT is
-accepted (and a missing one rejected with `unauthorized`), a Python-signed stream
-name is accepted for subscription, and an HTTP broadcast is delivered to the
-subscribed client.
 
 ## Related
 


### PR DESCRIPTION
Small cleanup from the soul/house-style review of the merged docs.

The Python guide carried two of the AI-shaped tells we're removing across the docs:

- **Decorative architecture ASCII diagram** — the intro paragraph already states the flow (issue a token, sign streams, POST broadcasts; AnyCable owns the socket), so the diagram added nothing. Removed.
- **A meta `## Verified behavior` section** — docs shouldn't narrate their own QA ("every step here is exercised against a running server…"); that belongs in a PR, not the page. Removed.
- Added a short **"That's it."** payoff after the broadcast step (Vladimir's house signature) where the flow is genuinely three HTTP-level pieces.

No content or accuracy change. forspell/markdownlint clean, build passes.

The front-door pages (`overview`, `quickstart`, `capabilities`, `editions`) hold up under the same lens and are left as-is; the use-case guides (the real soul problem) are being reworked separately.