### PR TITLE
Add Plausible analytics + a 'Something's missing' doc feedback button

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -38,6 +38,10 @@ export default withMermaid(defineConfig({
     ['meta', { name: 'twitter:card', content: 'summary_large_image' }],
     ['meta', { name: 'twitter:site', content: '@any_cable' }],
     ['meta', { name: 'keywords', content: 'anycable, websockets, real-time, realtime server, delivery guarantees, reliable streams, presence, action-cable, ruby, rails, hotwire, laravel, nodejs, python, go' }],
+    // Privacy-friendly analytics by Plausible (cookieless, no PII). The script ID is a
+    // public client-side identifier, not a secret; spoofing is blocked via hostname Shields.
+    ['script', { async: '', src: 'https://plausible.io/js/pa-sk7JDKlDe3CHAdBbykSWN.js' }],
+    ['script', {}, 'window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)},plausible.init=plausible.init||function(i){plausible.o=i||{}};\n  plausible.init()'],
   ],
 
   themeConfig: {

--- a/docs/.vitepress/theme/components/DocFeedback.vue
+++ b/docs/.vitepress/theme/components/DocFeedback.vue
@@ -1,0 +1,102 @@
+<script setup lang="ts">
+import { ref, computed } from 'vue'
+import { useData, useRoute } from 'vitepress'
+
+const route = useRoute()
+const { page } = useData()
+
+const sent = ref(false)
+
+// Built once per page, SSR-safe (no `window`/`location` at render time).
+const issueUrl = computed(() => {
+  const path = route.path
+  const source = page.value.relativePath // e.g. "quickstart.md"
+  const body = [
+    "What's missing, unclear, or wrong on this page?",
+    '',
+    '',
+    '---',
+    `Page: https://docs.anycable.io${path}`,
+    `Source: docs/${source}`,
+  ].join('\n')
+  const params = new URLSearchParams({
+    title: `Docs feedback: ${path}`,
+    body,
+  })
+  return `https://github.com/anycable/docs.anycable.io/issues/new?${params.toString()}`
+})
+
+// Fire the lightweight signal. Free text never goes to Plausible (PII/terms).
+function track(event: string) {
+  const plausible = (globalThis as any).plausible
+  if (typeof plausible === 'function') {
+    plausible(event, { props: { path: route.path } })
+  }
+}
+
+function report() {
+  track('Doc Incomplete')
+  sent.value = true
+}
+</script>
+
+<template>
+  <div class="doc-feedback">
+    <template v-if="!sent">
+      <span class="doc-feedback-q">Something missing or unclear on this page?</span>
+      <button class="doc-feedback-btn" type="button" @click="report">
+        Something's missing
+      </button>
+    </template>
+    <template v-else>
+      <span class="doc-feedback-q">Thanks, noted. Want to add specifics?</span>
+      <a
+        class="doc-feedback-btn"
+        :href="issueUrl"
+        target="_blank"
+        rel="noopener"
+        @click="track('Doc Feedback Detail')"
+      >
+        Add details on GitHub →
+      </a>
+    </template>
+  </div>
+</template>
+
+<style scoped>
+.doc-feedback {
+  margin-top: 1.25rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--vp-c-divider);
+  font-size: 0.75rem;
+  line-height: 1.5;
+}
+
+.doc-feedback-q {
+  display: block;
+  margin-bottom: 0.5rem;
+  color: var(--vp-c-text-2);
+}
+
+.doc-feedback-btn {
+  display: block;
+  width: 100%;
+  box-sizing: border-box;
+  padding: 0.4rem 0.6rem;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 8px;
+  color: var(--vp-c-text-1);
+  background: var(--vp-c-bg-soft);
+  font-size: 0.75rem;
+  font-weight: 500;
+  text-align: center;
+  cursor: pointer;
+  text-decoration: none;
+  transition: border-color 0.2s, color 0.2s;
+}
+
+.doc-feedback-btn:hover {
+  border-color: var(--vp-c-brand-1);
+  color: var(--vp-c-brand-1);
+}
+</style>

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -3,6 +3,7 @@ import { h } from 'vue'
 import type { Theme } from 'vitepress'
 import DefaultTheme from 'vitepress/theme'
 import AvailableSince from './components/AvailableSince.vue'
+import DocFeedback from './components/DocFeedback.vue'
 import LandingLayout from './layouts/LandingLayout.vue'
 import './style.css'
 
@@ -11,6 +12,9 @@ export default {
   Layout: () => {
     return h(DefaultTheme.Layout, null, {
       // https://vitepress.dev/guide/extending-default-theme#layout-slots
+      // Right aside (toolbar), under the page outline. Doc pages only, not the
+      // LandingLayout homepage.
+      'aside-outline-after': () => h(DocFeedback),
     })
   },
   enhanceApp({ app, router, siteData }) {


### PR DESCRIPTION
## What this adds

**1. Plausible analytics** (`config.mts`)
Privacy-friendly, cookieless analytics via the inline script. One shared property with the main `anycable.io` site (docs traffic is separable via Plausible's Hostname filter). The script ID is a public client-side identifier, not a secret, so it lives inline rather than in env.

**2. A "Something's missing" feedback button** (`theme/`)
A small widget in the right aside (under the page outline) on content pages, not the homepage. It turns reader friction into a ranked revision backlog:

- Click `Something's missing` → fires a Plausible `Doc Incomplete` custom event with the page `path` as a prop. Count per path = which pages readers find incomplete, most-reported first.
- Optional `Add details on GitHub →` → opens a **prefilled GitHub issue** (title + page URL + source path) and fires `Doc Feedback Detail`.

Free text goes to GitHub, never to Plausible, so there's no PII risk (Plausible's terms forbid PII in props) and no 2000-char prop limit to worry about.

## Verification
- `npm run build` passes; the snippet renders in `<head>` on every page; the widget renders in the aside on doc pages and is absent on the `LandingLayout` homepage.
- Reviewed locally via `npm run dev`.

## Follow-ups (dashboard / not code)
- Set a **Hostname Shield** to accept only `docs.anycable.io` + `anycable.io` (blocks spoofing of the public script ID; auto-rejects Netlify deploy previews and localhost).
- Create custom-event **goals** for `Doc Incomplete` and `Doc Feedback Detail`, and enable the `path` custom property, otherwise the events record but don't show as breakdowns.
- After deploy, confirm SPA pageviews register in Plausible's real-time view.
- Optional: create a `docs-feedback` GitHub label and I'll add `&labels=docs-feedback` to the issue link.