### PR TITLE
Auto-label doc feedback issues with docs-feedback

### DIFF
--- a/docs/.vitepress/theme/components/DocFeedback.vue
+++ b/docs/.vitepress/theme/components/DocFeedback.vue
@@ -22,6 +22,7 @@ const issueUrl = computed(() => {
   const params = new URLSearchParams({
     title: `Docs feedback: ${path}`,
     body,
+    labels: 'docs-feedback',
   })
   return `https://github.com/anycable/docs.anycable.io/issues/new?${params.toString()}`
 })


### PR DESCRIPTION
Follow-up to #62. The `docs-feedback` label now exists in the repo, so the prefilled GitHub issue from the "Something's missing" widget can apply it via `&labels=docs-feedback`.

It was deliberately omitted in #62 because a non-existent label can make GitHub's prefill URL error. With the label created, feedback issues are now auto-tagged and filterable by label, not just the `Docs feedback:` title prefix.

Build passes; the change is one line in the issue-URL params.